### PR TITLE
Fix remaining duplicate permission issues from #14995

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -61,7 +61,13 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \Pimcore\Db::get();
 
+        $existingKeys = $db->fetchFirstColumn('SELECT ' . $db->quoteIdentifier('key') . ' FROM users_permission_definitions');
+
         foreach (self::USER_PERMISSIONS as $permission) {
+            if (in_array($permission, $existingKeys)) {
+                continue;
+            } 
+
             $db->insert('users_permission_definitions', [
                 $db->quoteIdentifier('key') => $permission,
                 $db->quoteIdentifier('category') => self::USER_PERMISSIONS_CATEGORY,


### PR DESCRIPTION
As @solverat and @APochmann report there are still scenarios in which the Installer creates duplicate key issues in addPermissions().

These were not fixed by the PR mentioned in #14995 and I have just observed them after updating a legacy pimcore 10 web to 11.3.0

This adds the addPermission() changes suggested by @Apochmann in #14995.